### PR TITLE
Guzzle response getStatus() depecated

### DIFF
--- a/src/Crucial/Service/Chargify/Adjustment.php
+++ b/src/Crucial/Service/Chargify/Adjustment.php
@@ -108,7 +108,7 @@ class Adjustment extends AbstractEntity
         $response      = $service->request('subscriptions/' . (int)$subscriptionId . '/adjustments', 'POST', $rawData);
         $responseArray = $this->getResponseArray($response);
 
-        if (!$this->isError() && '201' == $response->getStatus()) {
+        if (!$this->isError() && '201' == $response->getStatusCode()) {
             $this->_data = $responseArray['adjustment'];
         } else {
             $this->_data = array();

--- a/src/Crucial/Service/Chargify/Component.php
+++ b/src/Crucial/Service/Chargify/Component.php
@@ -361,7 +361,7 @@ class Component extends AbstractEntity
 
         $responseArray = $this->getResponseArray($response);
 
-        if (!$this->isError() && '201' == $response->getStatus()) {
+        if (!$this->isError() && '201' == $response->getStatusCode()) {
             $this->_data = $responseArray['component'];
         } else {
             $this->_data = array();

--- a/src/Crucial/Service/Chargify/Coupon.php
+++ b/src/Crucial/Service/Chargify/Coupon.php
@@ -78,7 +78,7 @@ class Coupon extends AbstractEntity
         $responseArray = $this->getResponseArray($response);
 
         // status code must be 200, otherwise the code in $this->setCode() was not found
-        if (!$this->isError() && '200' == $response->getStatus()) {
+        if (!$this->isError() && '200' == $response->getStatusCode()) {
             $this->_data = $responseArray['coupon'];
         } else {
             $this->_data = array();

--- a/src/Crucial/Service/Chargify/Refund.php
+++ b/src/Crucial/Service/Chargify/Refund.php
@@ -107,7 +107,7 @@ class Refund extends AbstractEntity
         $response      = $service->request('subscriptions/' . (int)$subscriptionId . '/refunds', 'POST', $rawData);
         $responseArray = $this->getResponseArray($response);
 
-        if (!$this->isError() && '201' == $response->getStatus()) {
+        if (!$this->isError() && '201' == $response->getStatusCode()) {
             $this->_data = $responseArray['refund'];
         } else {
             $this->_data = array();

--- a/src/Crucial/Service/Chargify/Subscription.php
+++ b/src/Crucial/Service/Chargify/Subscription.php
@@ -494,7 +494,7 @@ class Subscription extends AbstractEntity
         $response      = $service->request('subscriptions/' . (int)$id . '/reactivate', 'PUT', '', $params);
         $responseArray = $this->getResponseArray($response);
 
-        $code = $response->getStatus();
+        $code = $response->getStatusCode();
 
         /**
          * add some more errors for a bad response code. errors will be in the body of the response


### PR DESCRIPTION
Not all $response->getStatus() calls were updated to getStatusCode() when Guzzle changed the method name.
