### PR TITLE
Reduce the Guzzle library restriction in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
     },
     "require": {
         "php": ">=5.5.0",
-        "guzzlehttp/guzzle": "6.1.1"
+        "guzzlehttp/guzzle": "~6.1"
     },
     "require-dev": {
         "phpunit/phpunit": "4.*",


### PR DESCRIPTION
Restricting to a specific minor release version is a bit too much, just a restriction on the library's major version should prevent any breaking changes but still allow projects using the chargify-sdk-php library more freedom in their Guzzle version selection.
