### PR TITLE
Make HTTP client timeout configurable

### DIFF
--- a/src/Crucial/Service/Chargify.php
+++ b/src/Crucial/Service/Chargify.php
@@ -88,8 +88,7 @@ class Chargify
      */
     protected $timeout = 10;
 
-
-    /**
+    /*
      * json
      *
      * @var string

--- a/src/Crucial/Service/Chargify.php
+++ b/src/Crucial/Service/Chargify.php
@@ -82,6 +82,14 @@ class Chargify
     protected $sharedKey;
 
     /**
+     * Timeout
+     *
+     * @var int
+     */
+    protected $timeout = 10;
+
+
+    /**
      * json
      *
      * @var string
@@ -115,10 +123,15 @@ class Chargify
         $this->apiKey    = $config['api_key'];
         $this->sharedKey = $config['shared_key'];
 
+        if (!empty($config['timeout'])) {
+            $this->timeout   = $config['timeout'];
+        }
+
+
         $this->httpClient = new Client([
             'base_uri'        => 'https://' . $this->hostname . '/',
             'handler'         => HandlerStack::create(),
-            'timeout'         => 10,
+            'timeout'         => $this->timeout,
             'allow_redirects' => false,
             'auth'            => [$this->apiKey, $this->password],
             'headers'         => [


### PR DESCRIPTION
Chargify's API has been taking more than 10 seconds to respond to some of my requests. This change makes the timeout user configurable.