### PR TITLE
Added Coupon::findValid()

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
-    "name": "chargely/chargify-sdk-php",
-    "homepage": "https://github.com/chargely/chargify-sdk-php",
-    "description": "Chargify SDK for PHP - Use the Chargify API in your PHP project",
+    "name": "bnt-ar/chargify-sdk-php",
+    "homepage": "https://github.com/BNT-AR/chargify-sdk-php",
+    "description": "Chargify SDK for PHP - Use the Chargify API in your PHP project. Fork of chargely/chargify-sdk-php",
     "keywords": [
         "chargify",
         "chargify direct",
@@ -9,19 +9,18 @@
         "billing portal",
         "api",
         "sdk",
-        "php",
-        "chargely"
+        "php"
     ],
     "type": "library",
     "license": "Apache-2.0",
     "authors": [
         {
-            "name": "Chargely",
-            "homepage": "http://www.chargely.com"
+            "name": "BNT-AR",
+            "homepage": "http://www.bravenew.tech"
         }
     ],
     "support": {
-        "issues": "https://github.com/chargely/chargify-sdk-php/issues"
+        "issues": "https://github.com/BNT-AR/chargify-sdk-php/issues"
     },
     "require": {
         "php": ">=5.5.0",

--- a/src/Crucial/Service/Chargify/Coupon.php
+++ b/src/Crucial/Service/Chargify/Coupon.php
@@ -86,4 +86,29 @@ class Coupon extends AbstractEntity
 
         return $this;
     }
+
+    /**
+     * Find a Valid Coupon
+     * Works similar to Coupon::find(), except that returns the Coupon object
+     * only when the coupon is found and valid
+     *
+     * @param int $productFamilyId
+     *
+     * @return Coupon
+     * @see  Coupon::setCode()
+     */
+    public function findValid($productFamilyId) {
+        $service       = $this->getService();
+        $response      = $service->request('product_families/' . $productFamilyId . '/coupons/validate', 'GET', NULL, $this->_params);
+        $responseArray = $this->getResponseArray($response);
+
+        // status code must be 200, otherwise the code in $this->setCode() was not found
+        if (!$this->isError() && '200' == $response->getStatusCode()) {
+            $this->_data = $responseArray['coupon'];
+        } else {
+            $this->_data = array();
+        }
+
+        return $this;
+    }
 }


### PR DESCRIPTION
Hi, 

I added a Coupon::findValid() method that implements the following Chargify method: https://reference.chargify.com/v1/coupons/validate-a-coupon

The main difference between `find()` and `findValid()` is that the coupon is retrieved only when it exists and is valid.

Usage:
```php
$chargify->coupon()
    ->setCode($coupon_code)
    ->findValid($product_family_id);
return $coupon->isError();
```