### PR TITLE
Upgrade Guzzle dependency to 7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
     },
     "require": {
         "php": ">=5.5.0",
-        "guzzlehttp/guzzle": "^6.0"
+        "guzzlehttp/guzzle": "^7.0"
     },
     "require-dev": {
         "phpunit/phpunit": "4.*",


### PR DESCRIPTION
It will allow use of chargify sdk with new Laravel, that depends on Guzzle7, the tests are not broken.